### PR TITLE
Add unclassified tag to projects

### DIFF
--- a/src/main/java/edu/stanford/protege/metaproject/api/Project.java
+++ b/src/main/java/edu/stanford/protege/metaproject/api/Project.java
@@ -31,4 +31,5 @@ public interface Project extends PolicyObject<ProjectId>, HasDescription, Compar
     @Nonnull
     Optional<ProjectOptions> getOptions();
 
+	boolean classified();
 }

--- a/src/main/java/edu/stanford/protege/metaproject/impl/ProjectImpl.java
+++ b/src/main/java/edu/stanford/protege/metaproject/impl/ProjectImpl.java
@@ -81,6 +81,11 @@ public final class ProjectImpl implements Project, Serializable {
         return false;
     }
 
+	@Override
+	public boolean classified() {
+		return false;
+	}
+
     @Override
     public boolean isProject() {
         return true;


### PR DESCRIPTION
I've made an explicit part of the interface rather than relying on the untyped
`options`. For now all projects are unclassified.

Bear with me on the needless Project/ProjectImpl for now. I will nix it in
another commit.